### PR TITLE
Implement Twilio voice webhook

### DIFF
--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -21,10 +21,10 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v4
 
-      - name: Set up Python 3.11
+      - name: Set up Python 3.12
         uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: '3.12'
       
       - name: Install dependencies
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+FROM python:3.12-slim
+
+WORKDIR /app
+
+# Install Promtail
+RUN apt-get update && \
+    apt-get install -y curl unzip && \
+    curl -L -o /tmp/promtail.zip https://github.com/grafana/loki/releases/download/v2.9.5/promtail-linux-amd64.zip && \
+    unzip /tmp/promtail.zip -d /usr/local/bin && \
+    mv /usr/local/bin/promtail-linux-amd64 /usr/local/bin/promtail && \
+    chmod +x /usr/local/bin/promtail && \
+    rm -rf /var/lib/apt/lists/* /tmp/promtail.zip
+
+COPY backend /app/backend
+COPY pyproject.toml /app/pyproject.toml
+
+RUN pip install --no-cache-dir fastapi uvicorn
+
+COPY promtail-config.yml /etc/promtail.yml
+
+CMD sh -c "promtail -config.file=/etc/promtail.yml & uvicorn backend.app.main:app --host 0.0.0.0 --port 8000 --workers 1"

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,0 +1,14 @@
+from fastapi import FastAPI
+from fastapi.responses import Response
+
+app = FastAPI()
+
+
+@app.post("/voice")
+async def voice():
+    """Return a simple greeting for Twilio Voice."""
+    twiml = (
+        "<?xml version='1.0' encoding='UTF-8'?>"
+        "<Response><Say>Hola, gracias por llamar</Say></Response>"
+    )
+    return Response(content=twiml, media_type="text/xml")

--- a/backend/tests/test_voice.py
+++ b/backend/tests/test_voice.py
@@ -1,0 +1,11 @@
+from fastapi.testclient import TestClient
+from backend.app.main import app
+
+client = TestClient(app)
+
+
+def test_voice_endpoint():
+    response = client.post("/voice")
+    assert response.status_code == 200
+    assert "<Say>Hola" in response.text
+    assert response.headers["content-type"].startswith("text/xml")

--- a/promtail-config.yml
+++ b/promtail-config.yml
@@ -1,0 +1,22 @@
+server:
+  http_listen_port: 9080
+  grpc_listen_port: 0
+
+positions:
+  filename: /tmp/positions.yaml
+
+clients:
+  - url: $LOKI_URL
+    basic_auth:
+      username: $LOKI_USER
+      password: $LOKI_PASSWORD
+
+scrape_configs:
+  - job_name: app
+    static_configs:
+      - targets:
+          - localhost
+        labels:
+          job: backend
+          __path__: /var/log/*log
+

--- a/railway.json
+++ b/railway.json
@@ -1,0 +1,8 @@
+{
+  "build": {
+    "builder": "Dockerfile"
+  },
+  "deploy": {
+    "healthcheckPath": "/docs"
+  }
+}


### PR DESCRIPTION
## Summary
- add a simple FastAPI application with a `/voice` endpoint
- provide Dockerfile and Railway config
- add Promtail configuration for Loki logging
- update CI to Python 3.12
- add unit test for `/voice`

## Testing
- `ruff check backend`
- `black --check backend`
- `pytest` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6872d9e3352c8329933c94c9a03c8294