### PR TITLE
Handle media frames in STT

### DIFF
--- a/backend/tests/test_voice.py
+++ b/backend/tests/test_voice.py
@@ -6,12 +6,11 @@ client = TestClient(app)
 
 
 def test_voice_endpoint(monkeypatch):
-    monkeypatch.setattr(tts, "speak", lambda text: "https://audio/file.mp3")
-    monkeypatch.setattr(
-        "backend.app.main.speak",
-        lambda text: "https://audio/file.mp3",
-        raising=False,
-    )
+    async def fake_speak(text: str):
+        return "https://audio/file.mp3"
+
+    monkeypatch.setattr(tts, "speak", fake_speak)
+    monkeypatch.setattr("backend.app.main.speak", fake_speak, raising=False)
     response = client.post("/voice")
     assert response.status_code == 200
     assert "<Play>https://audio/file.mp3</Play>" in response.text
@@ -19,7 +18,7 @@ def test_voice_endpoint(monkeypatch):
 
 
 def test_voice_endpoint_fallback(monkeypatch):
-    def fail_speak(text: str):
+    async def fail_speak(text: str):
         raise RuntimeError("boom")
 
     monkeypatch.setattr(tts, "speak", fail_speak)

--- a/fastapi/__init__.py
+++ b/fastapi/__init__.py
@@ -3,7 +3,7 @@ from typing import Callable, Dict, Tuple
 # Re-export key helpers to mimic the real package structure
 from . import testclient, responses
 
-__all__ = ["FastAPI", "Response", "testclient", "responses"]
+__all__ = ["FastAPI", "Response", "WebSocket", "testclient", "responses"]
 
 
 class Response:
@@ -11,6 +11,20 @@ class Response:
         self.content = content
         self.text = content
         self.headers = {"content-type": media_type}
+
+
+class WebSocket:
+    async def accept(self) -> None:  # pragma: no cover - stub
+        pass
+
+    async def receive_json(self):  # pragma: no cover - stub
+        pass
+
+    async def receive(self):  # pragma: no cover - stub
+        pass
+
+    async def send_text(self, data: str) -> None:  # pragma: no cover - stub
+        pass
 
 
 class FastAPI:

--- a/fastapi/testclient.py
+++ b/fastapi/testclient.py
@@ -37,6 +37,9 @@ class TestClient:
         def send_bytes(self, data: bytes) -> None:
             self.incoming.append(data)
 
+        def send_text(self, text: str) -> None:
+            self.incoming.append(text)
+
         def __enter__(self):
             return self
 
@@ -47,12 +50,25 @@ class TestClient:
                         self._in = incoming
                         self._out = outgoing
 
-                    def receive_bytes(self):
-                        if self._in:
-                            return self._in.pop(0)
-                        return b""
+                    async def accept(self):
+                        pass
 
-                    def send_text(self, text: str):
+                    async def receive(self):
+                        if self._in:
+                            item = self._in.pop(0)
+                            if isinstance(item, bytes):
+                                return {"bytes": item}
+                            return {"text": item}
+                        return None
+
+                    async def receive_json(self):
+                        if self._in:
+                            import json
+
+                            return json.loads(self._in.pop(0))
+                        return {}
+
+                    async def send_text(self, text: str):
                         self._out.append(text)
 
                 ws = FakeWS(self.incoming, self.outgoing)

--- a/httpx/__init__.py
+++ b/httpx/__init__.py
@@ -25,3 +25,17 @@ def post(url, headers=None, json=None):
 
 def put(url, content=None, headers=None):
     return Response()
+
+
+class AsyncClient:
+    def __init__(self, *args, **kwargs):
+        pass
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        pass
+
+    async def post(self, url, headers=None, json=None, files=None):
+        return Response()

--- a/tenacity/__init__.py
+++ b/tenacity/__init__.py
@@ -1,5 +1,5 @@
 class wait_random_exponential:
-    def __init__(self, multiplier=1, max=60):
+    def __init__(self, multiplier=1, max=60, **kwargs):
         self.multiplier = multiplier
         self.max = max
 
@@ -12,7 +12,11 @@ def retry(*dargs, **dkwargs):
     def decorator(fn):
         def wrapper(*args, **kwargs):
             return fn(*args, **kwargs)
-        
+
         return wrapper
-    
+
     return decorator
+
+
+class AsyncRetrying:
+    pass


### PR DESCRIPTION
## Summary
- parse base64-encoded media frames for speech to text
- extend fastapi test stubs for JSON frames
- update tests for async APIs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687be4d9894083298ecafc810afaea01