### PR TITLE
Handle silence in STT stream

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -21,20 +21,9 @@ async def websocket_stt(websocket: WebSocket):
     try:
         # El primer mensaje de Twilio Media Streams suele ser un JSON con el evento "start"
         initial_message = await websocket.receive_json()
-        if initial_message.get("event") == "start":
-            call_sid = initial_message.get("start", {}).get("callSid")
-            if call_sid:
-                call_id = call_sid
-                print(f"[{call_id}] Received callSid: {call_id}") # Para depuración
-    except Exception as e:
-        print(f"Error receiving initial WebSocket message or call_id: {e}")
-        # Continuar con el call_id por defecto si falla la obtención
-    
-    # stt.process_stream ahora debe ser una función asíncrona
-    # En backend/app/main.py, dentro de websocket_stt
-    try:
-        initial_message = await websocket.receive_json()
-        print(f"DEBUG: Initial WebSocket message from Twilio: {json.dumps(initial_message, indent=2)}") # Añade esto
+        print(
+            f"DEBUG: Initial WebSocket message from Twilio: {json.dumps(initial_message, indent=2)}"
+        )
         if initial_message.get("event") == "start":
             call_sid = initial_message.get("start", {}).get("callSid")
             if call_sid:

--- a/backend/app/stt.py
+++ b/backend/app/stt.py
@@ -7,7 +7,7 @@ import wave
 import httpx
 import json
 import base64
-from fastapi import WebSocket # Necesario para tipado y métodos asíncronos
+from fastapi import WebSocket  # Necesario para tipado y métodos asíncronos
 
 from .supabase import save_transcript
 
@@ -18,6 +18,17 @@ WHISPER_SAMPLE_RATE = 16000
 CHUNK_SECONDS = 5
 CHUNK_SIZE = INPUT_SAMPLE_RATE * CHUNK_SECONDS  # bytes for μ-law (1 byte por muestra)
 
+# Threshold based silence detection
+SILENCE_THRESHOLD = int(os.getenv("SILENCE_THRESHOLD", "500"))
+SILENCE_DURATION = float(os.getenv("SILENCE_DURATION", "0.3"))
+
+# Maximum length of a buffered segment in seconds
+MAX_SEGMENT_SECONDS = int(os.getenv("MAX_SEGMENT_SECONDS", "10"))
+MAX_SEGMENT_SIZE = INPUT_SAMPLE_RATE * MAX_SEGMENT_SECONDS
+MIN_SEGMENT_SECONDS = float(os.getenv("MIN_SEGMENT_SECONDS", "0.1"))
+MIN_SEGMENT_SIZE = int(INPUT_SAMPLE_RATE * MIN_SEGMENT_SECONDS)
+
+
 
 def mulaw_to_wav(data: bytes) -> bytes:
     """Convierte audio μ-law en un archivo WAV."""
@@ -25,9 +36,7 @@ def mulaw_to_wav(data: bytes) -> bytes:
     sample_rate = INPUT_SAMPLE_RATE
 
     if INPUT_SAMPLE_RATE != WHISPER_SAMPLE_RATE:
-        pcm, _ = audioop.ratecv(
-            pcm, 2, 1, INPUT_SAMPLE_RATE, WHISPER_SAMPLE_RATE, None
-        )
+        pcm, _ = audioop.ratecv(pcm, 2, 1, INPUT_SAMPLE_RATE, WHISPER_SAMPLE_RATE, None)
         sample_rate = WHISPER_SAMPLE_RATE
 
     buffer = io.BytesIO()
@@ -37,6 +46,7 @@ def mulaw_to_wav(data: bytes) -> bytes:
         wf.setframerate(sample_rate)
         wf.writeframes(pcm)
     return buffer.getvalue()
+
 
 def preprocess_wav(wav: bytes) -> bytes:
     """Ajusta ganancia y aplica un filtro pasa alto básico."""
@@ -52,7 +62,7 @@ def preprocess_wav(wav: bytes) -> bytes:
     prev = 0
     hp = 0.95
     for i in range(0, len(frames), 2):
-        sample = int.from_bytes(frames[i:i+2], "little", signed=True)
+        sample = int.from_bytes(frames[i : i + 2], "little", signed=True)
         sample = int(sample * gain)
         filtered = sample - int(prev * hp)
         prev = sample
@@ -68,7 +78,6 @@ def preprocess_wav(wav: bytes) -> bytes:
     return out.getvalue()
 
 
-
 def transcribe_chunk(wav: bytes) -> str:
     """Envía audio a Whisper y devuelve el texto."""
     api_key = os.environ.get("OPENAI_API_KEY")
@@ -77,19 +86,25 @@ def transcribe_chunk(wav: bytes) -> str:
     headers = {"Authorization": f"Bearer {api_key}"}
     files = {"file": ("audio.wav", wav, "audio/wav")}
     data = {"model": "whisper-1", "language": "es"}
-    
+
     try:
         resp = httpx.post(
-            "https://api.openai.com/v1/audio/transcriptions", headers=headers, data=data, files=files, timeout=5 # Añadir timeout
+            "https://api.openai.com/v1/audio/transcriptions",
+            headers=headers,
+            data=data,
+            files=files,
+            timeout=5,  # Añadir timeout
         )
-        resp.raise_for_status() # Lanza un HTTPStatusError para códigos de error 4xx/5xx
+        resp.raise_for_status()  # Lanza un HTTPStatusError para códigos de error 4xx/5xx
         return resp.json().get("text", "")
     except httpx.RequestError as e:
         print(f"An error occurred while requesting Whisper API: {e}")
-        return "" # Devuelve cadena vacía en caso de error de red/conexión
+        return ""  # Devuelve cadena vacía en caso de error de red/conexión
     except httpx.HTTPStatusError as e:
-        print(f"Whisper API returned an error {e.response.status_code}: {e.response.text}")
-        return "" # Devuelve cadena vacía en caso de error de API
+        print(
+            f"Whisper API returned an error {e.response.status_code}: {e.response.text}"
+        )
+        return ""  # Devuelve cadena vacía en caso de error de API
 
 
 async def process_stream(ws: WebSocket, call_id: str) -> None:
@@ -99,12 +114,13 @@ async def process_stream(ws: WebSocket, call_id: str) -> None:
     """
     buffer = b""
     ts_start = time.time()
-    
+    last_voice_ts = ts_start
+
     print(f"[{call_id}] Starting STT stream processing.")
 
-    stream_active = True # Controla el bucle principal
+    stream_active = True  # Controla el bucle principal
     try:
-        while stream_active: 
+        while stream_active:
             message = await ws.receive()  # Espera por cualquier tipo de mensaje
 
             if "text" in message:
@@ -116,22 +132,39 @@ async def process_stream(ws: WebSocket, call_id: str) -> None:
                     if event == "media":
                         payload_b64 = control_data.get("media", {}).get("payload", "")
                         if payload_b64:
-                            buffer += base64.b64decode(payload_b64)
+                            data = base64.b64decode(payload_b64)
+                            buffer += data
 
-                            while len(buffer) >= CHUNK_SIZE:
-                                raw = buffer[:CHUNK_SIZE]
-                                buffer = buffer[CHUNK_SIZE:]
+                            energy = audioop.rms(audioop.ulaw2lin(data, 2), 2)
+                            now = time.time()
+                            if energy > SILENCE_THRESHOLD:
+                                last_voice_ts = now
 
-                                wav = preprocess_wav(mulaw_to_wav(raw))
-                                text = transcribe_chunk(wav)
-                                ts_end = time.time()
-
-                                if text and text.strip():
-                                    await save_transcript(call_id, ts_start, ts_end, text)
-                                    print(f"[{call_id}] Transcribed: {text}")
-                                    await ws.send_text(text)
-
-                                ts_start = ts_end
+                            duration_buffer = len(buffer) / INPUT_SAMPLE_RATE
+                            if (
+                                (now - last_voice_ts) >= SILENCE_DURATION
+                                or duration_buffer >= MAX_SEGMENT_SECONDS
+                            ):
+                                if len(buffer) >= MIN_SEGMENT_SIZE:
+                                    wav = preprocess_wav(mulaw_to_wav(buffer))
+                                    text = transcribe_chunk(wav)
+                                    ts_end = now
+                                    if text and text.strip():
+                                        await save_transcript(
+                                            call_id,
+                                            ts_start,
+                                            ts_end,
+                                            text,
+                                        )
+                                        print(f"[{call_id}] Transcribed: {text}")
+                                        await ws.send_text(text)
+                                else:
+                                    print(
+                                        f"[{call_id}] Skipping short audio chunk ({len(buffer)} bytes)"
+                                    )
+                                ts_start = now
+                                buffer = b""
+                                last_voice_ts = now
 
                     elif event == "stop":
                         print(f"[{call_id}] Twilio Media Stream 'stop' event received.")
@@ -140,26 +173,41 @@ async def process_stream(ws: WebSocket, call_id: str) -> None:
                             print(
                                 f"[{call_id}] Processing remaining buffer ({len(buffer)} bytes) before stopping."
                             )
-                            wav = preprocess_wav(mulaw_to_wav(buffer))
-                            text = transcribe_chunk(wav)
-                            ts_end = time.time()
-                            if text and text.strip():
-                                await save_transcript(call_id, ts_start, ts_end, text)
-                                print(f"[{call_id}] Transcribed (final chunk): {text}")
+                            if len(buffer) >= MIN_SEGMENT_SIZE:
+                                wav = preprocess_wav(mulaw_to_wav(buffer))
+                                text = transcribe_chunk(wav)
+                                ts_end = time.time()
+                                if text and text.strip():
+                                    await save_transcript(call_id, ts_start, ts_end, text)
+                                    print(f"[{call_id}] Transcribed (final chunk): {text}")
+                                    await ws.send_text(text)
+                            else:
+                                print(f"[{call_id}] Skipping short audio chunk ({len(buffer)} bytes)")
+                                ts_end = time.time()
+                            buffer = b""
+                            last_voice_ts = ts_end
 
                         stream_active = False
                     else:
                         print(f"[{call_id}] Received control message: {event}")
 
                 except json.JSONDecodeError:
-                    print(f"[{call_id}] Received non-JSON text message: {message['text']}")
-            
-            elif message is None: # La conexión WebSocket se cerró inesperadamente por el cliente
-                print(f"[{call_id}] WebSocket connection closed by client unexpectedly.")
-                stream_active = False # Salir del bucle
-                
+                    print(
+                        f"[{call_id}] Received non-JSON text message: {message['text']}"
+                    )
+
+            elif (
+                message is None
+            ):  # La conexión WebSocket se cerró inesperadamente por el cliente
+                print(
+                    f"[{call_id}] WebSocket connection closed by client unexpectedly."
+                )
+                stream_active = False  # Salir del bucle
+
     except Exception as e:
         print(f"[{call_id}] Error processing stream: {e}")
     finally:
-        print(f"[{call_id}] STT stream processing finished. Final buffer size: {len(buffer)}")
+        print(
+            f"[{call_id}] STT stream processing finished. Final buffer size: {len(buffer)}"
+        )
         # El búfer ya fue procesado si se recibió un evento 'stop'.

--- a/backend/tests/test_preprocess.py
+++ b/backend/tests/test_preprocess.py
@@ -1,0 +1,30 @@
+import math
+import struct
+import io
+import wave
+import audioop
+
+from backend.app.stt import mulaw_to_wav, preprocess_wav, INPUT_SAMPLE_RATE
+
+
+def _duration(wav_bytes: bytes) -> float:
+    with wave.open(io.BytesIO(wav_bytes), "rb") as wf:
+        return wf.getnframes() / wf.getframerate()
+
+
+def test_preprocess_modifies_audio_preserves_duration():
+    # generate 1 second sine wave as mu-law
+    sr = INPUT_SAMPLE_RATE
+    pcm = b"".join(
+        struct.pack("<h", int(10000 * math.sin(2 * math.pi * 440 * i / sr)))
+        for i in range(sr)
+    )
+    mu = audioop.lin2ulaw(pcm, 2)
+    wav = mulaw_to_wav(mu)
+    before = _duration(wav)
+
+    processed = preprocess_wav(wav)
+    after = _duration(processed)
+
+    assert before == after
+    assert wav != processed


### PR DESCRIPTION
## Summary
- detect silence in stream and split audio accordingly
- send final transcription on stop event
- skip segments shorter than OpenAI's minimum length

## Testing
- `black backend/app/stt.py` *(fails: command not found)*
- `ruff check backend/app/stt.py` *(fails: command not found)*
- `pytest -q` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6881316504f4832986f17c931288fd78